### PR TITLE
Fix cross-platform path compatibility for Windows

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,7 +154,8 @@ class BrowserSession:
 
 class AIBrowserHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, directory="/home/ubuntu/repos/first-draft-1.1", **kwargs)
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        super().__init__(*args, directory=script_dir, **kwargs)
     
     def do_GET(self):
         if self.path == '/':

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -2,6 +2,7 @@ import webview
 import threading
 import json
 import os
+import platform
 from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
@@ -10,7 +11,9 @@ import time
 
 class AIBrowserApp:
     def __init__(self):
-        self.storage_path = "/home/ubuntu/scraped_data"
+        DEFAULT_WINDOWS_PATH = r"C:\Users\yosef\OneDrive\Desktop\Attachments"
+        DEFAULT_LINUX_PATH = "/home/ubuntu/scraped_data"
+        self.storage_path = os.environ.get('AI_STORAGE_PATH', DEFAULT_WINDOWS_PATH if platform.system() == 'Windows' else DEFAULT_LINUX_PATH)
         os.makedirs(self.storage_path, exist_ok=True)
         
         self.ai_services = {


### PR DESCRIPTION
# Fix cross-platform path compatibility for Windows

## Summary
Fixes 404 errors when running `startup.bat` on Windows by replacing hardcoded Linux paths with dynamic cross-platform path detection.

**Changes:**
- **app.py**: Replace hardcoded `/home/ubuntu/repos/first-draft-1.1` server directory with `os.path.dirname(os.path.abspath(__file__))` for dynamic script directory detection
- **desktop_app.py**: Replace hardcoded Linux storage path with platform detection logic (similar to existing pattern in app.py)

The root cause was that `AIBrowserHandler` was hardcoded to serve files from a Linux-specific directory that doesn't exist on Windows, preventing the server from finding `templates/index.html` and static files.

## Review & Testing Checklist for Human
- [ ] **Test on Windows**: Run `startup.bat` and verify that `http://localhost:5001/` loads without 404 errors
- [ ] **Verify file serving**: Confirm that templates/index.html and static files (CSS, JS) load correctly in the browser
- [ ] **Test desktop app**: Ensure desktop_app.py works with the new cross-platform storage path logic
- [ ] **Check Windows path**: Verify the hardcoded `C:\Users\yosef\OneDrive\Desktop\Attachments` path works or consider making it more generic

### Notes
- I was only able to test on Linux where the application works correctly, but the actual 404 issue occurs on Windows
- The web interface loads properly on Linux (confirmed via browser test), showing the 4-panel AI interface without errors
- Session: https://app.devin.ai/sessions/33df968dc7114a6e8533cd50b8b5e8c7 by @YosefGoodman